### PR TITLE
Give the impure cache method a parentheses

### DIFF
--- a/Tensors/src/main/scala/com/thoughtworks/compute/Tensors.scala
+++ b/Tensors/src/main/scala/com/thoughtworks/compute/Tensors.scala
@@ -1213,7 +1213,7 @@ trait Tensors extends OpenCL {
       *
       * @group slow
       */
-    def cache: AutoCloseable = {
+    def cache(): AutoCloseable = {
       sealed trait State
       case object Openning extends State
       case object EarlyClosed extends State


### PR DESCRIPTION
According to http://docs.scala-lang.org/style/method-invocation.html