### PR TITLE
Remove unnecessary `lwjgl` dependency

### DIFF
--- a/OpenCL/build.sbt
+++ b/OpenCL/build.sbt
@@ -11,8 +11,6 @@ libraryDependencies += ("org.lwjgl" % "lwjgl" % "3.1.6" % Optional).jar().classi
   }
 }
 
-libraryDependencies += "org.lwjgl" % "lwjgl" % "3.1.6"
-
 libraryDependencies += "org.lwjgl" % "lwjgl-opencl" % "3.1.6"
 
 libraryDependencies += "com.thoughtworks.raii" %% "asynchronous" % "3.0.0-M11"


### PR DESCRIPTION
This dependency should be added by `lwjgl-opencl` automatically